### PR TITLE
Add PHPUnit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /test.php
+vendor/
+composer.lock
+.phpunit.result.cache

--- a/Demo/array.php
+++ b/Demo/array.php
@@ -1,14 +1,12 @@
-<?
-include_once("../jsnao.php");
+<?php
+require_once __DIR__ . '/../jsnao.php';
 
 // 購物車
-$cart = array
-(
-    '001'   =>  array
-    (
-        'name'  =>  'apple',
-    )
-);
+$cart = [
+    '001' => [
+        'name' => 'apple',
+    ],
+];
 
 $cart = new Jsnao($cart);
 
@@ -16,13 +14,13 @@ $cart = new Jsnao($cart);
 $cart['001']['name']; // output: apple
 
 // 賦值
-$cart['002']['name'] = "banana"; 
+$cart['002']['name'] = 'banana';
 
 // 修改
-$cart['001']['name'] = "cherry"; 
+$cart['001']['name'] = 'cherry';
 
 // 刪除
-$cart['003']['name'] = "bag";
+$cart['003']['name'] = 'bag';
 unset($cart['003']);
 
 echo $cart;

--- a/Demo/array.php
+++ b/Demo/array.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../jsnao.php';
+require_once __DIR__ . '/../Jsnao.php';
 
 // 購物車
 $cart = [

--- a/Demo/org.php
+++ b/Demo/org.php
@@ -1,29 +1,26 @@
-<?
-include_once("../jsnao.php");
+<?php
+require_once __DIR__ . '/../jsnao.php';
 
 // 購物車
-$cart = array
-(
-    '001'   =>  array
-    (
-        'name'  =>  'apple',
-    )
-);
+$cart = [
+    '001' => [
+        'name' => 'apple',
+    ],
+];
 
 $cart = new Jsnao($cart);
-
 
 // 取值
 $cart->offsetGet('001')->name; //output: apple
 
 // 賦值
-$cart->offsetSet('002', array('name' => 'banana')); //output: apple
+$cart->offsetSet('002', ['name' => 'banana']);
 
 // 修改
 $cart->offsetGet('001')->offsetSet('name', 'cherry');
 
 // 刪除
-$cart->offsetSet('003', array('name' => 'bag')); 
-$cart->offsetUnset('003'); 
+$cart->offsetSet('003', ['name' => 'bag']);
+$cart->offsetUnset('003');
 
 echo $cart;

--- a/Demo/org.php
+++ b/Demo/org.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../jsnao.php';
+require_once __DIR__ . '/../Jsnao.php';
 
 // 購物車
 $cart = [

--- a/Demo/simple.php
+++ b/Demo/simple.php
@@ -1,18 +1,15 @@
-<?
-include_once("../jsnao.php");
+<?php
+require_once __DIR__ . '/../jsnao.php';
 
-$cart = array
-(
-    'A001'   =>  array
-    (
-        'name'  =>  'apple',
-    ),
-    1000 => array
-    (
-        'name'  => 'water'
-    )
-);
-$cart = new jsnao($cart);
+$cart = [
+    'A001' => [
+        'name' => 'apple',
+    ],
+    1000 => [
+        'name' => 'water',
+    ],
+];
+$cart = new Jsnao($cart);
 
 // 取值
 $cart->A001->name; //output: apple
@@ -20,18 +17,18 @@ $cart->A001->name; //output: apple
 $cart->get(1000)->name;
 
 // 賦值
-$cart->A002 = array('name' => 'banana');
+$cart->A002 = ['name' => 'banana'];
 //或
-$cart->A002 = array();
+$cart->A002 = [];
 $cart->A002->name = 'banana';
 //或
-$cart->put(2000, array('name' => 'lemon'));
+$cart->put(2000, ['name' => 'lemon']);
 
 // 修改
 $cart->A001->name = 'cherry';
 
 // 刪除
-$cart->A003 = array('name' => 'bag');
+$cart->A003 = ['name' => 'bag'];
 unset($cart->A003);
 
 echo $cart;

--- a/Demo/simple.php
+++ b/Demo/simple.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../jsnao.php';
+require_once __DIR__ . '/../Jsnao.php';
 
 $cart = [
     'A001' => [

--- a/Jsnao.php
+++ b/Jsnao.php
@@ -1,12 +1,14 @@
 <?php
 declare(strict_types=1);
 
+namespace Jsnao;
+
 /**
  * 取材自網友 http://bbs.phpchina.com/thread-123682-1-1.html
  */
-require_once __DIR__ . '/jsnao_inputype.php';
 
-class Jsnao extends ArrayObject
+
+class Jsnao extends \ArrayObject
 {
     protected string $version = '1.1.4';
 
@@ -16,7 +18,7 @@ class Jsnao extends ArrayObject
      */
     public function __construct(mixed $mix = null)
     {
-        $array = Jsnao_inputype::filter($mix);
+        $array = JsnaoInputType::filter($mix);
         foreach ($array as &$value) {
             if (is_array($value)) {
                 $value = new self($value);

--- a/JsnaoInputType.php
+++ b/JsnaoInputType.php
@@ -1,10 +1,12 @@
 <?php
 declare(strict_types=1);
 
+namespace Jsnao;
+
 /**
  * 輸入的格式過濾，最後都會回傳陣列
  */
-class Jsnao_inputype
+class JsnaoInputType
 {
     //唯一對外的呼叫方法。依照輸入的型態對應適合的方法
     public static function filter(mixed $mix): array

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jsnao authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $result = new Jsnao($mix);
 
 ## 一般用法
 ````php
-include_once("../jsnao.php");
+include_once("../Jsnao.php");
 
 $cart = array
 (
@@ -96,7 +96,7 @@ echo $cart;
 ## 陣列用法
 ````php
 <?php
-include_once("../jsnao.php");
+include_once("../Jsnao.php");
 
 // 購物車
 $cart = array
@@ -128,7 +128,7 @@ echo $cart;
 ## 繼承 ArrayObject 原生用法
 ````php
 <?php
-include_once("../jsnao.php");
+include_once("../Jsnao.php");
 
 // 購物車
 $cart = array
@@ -224,3 +224,14 @@ echo $data->profile->log()->phone;
 $result = new jsnao($array);
 echo $result;
 ````
+
+## 安裝與測試
+安裝 PHP 8.3 以上與 Composer 後，執行下列指令安裝套件並跑測試：
+
+```bash
+composer install
+vendor/bin/phpunit --configuration phpunit.xml.dist
+```
+
+也可以直接執行 `setup.sh` 自動完成安裝與測試。
+

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ echo $cart;
 
 ## 陣列用法
 ````php
-<?
+<?php
 include_once("../jsnao.php");
 
 // 購物車
@@ -127,7 +127,7 @@ echo $cart;
 
 ## 繼承 ArrayObject 原生用法
 ````php
-<?
+<?php
 include_once("../jsnao.php");
 
 // 購物車

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,24 @@
 {
-    "name": "jsnlib/jsnao",
-    "type": "library",
-    "description": "easy use ArrayObject",
-    "keywords": ["array", "object", "convert", "ArrayObject"],
-    "license": "MIT",
-    "homepage": "https://github.com/fdjkgh580/jsnao",
-    "require": {
-        "php": ">=5.2.4"
-    },
-    "autoload": {
-        "classmap": ["jsnao.php"]
-    }
+  "name": "jsnlib/jsnao",
+  "type": "library",
+  "description": "easy use ArrayObject",
+  "keywords": [
+    "array",
+    "object",
+    "convert",
+    "ArrayObject"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/fdjkgh580/jsnao",
+  "require": {
+    "php": ">=8.0"
+  },
+  "autoload": {
+    "classmap": [
+      "jsnao.php"
+    ]
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^10"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     "php": ">=8.0"
   },
   "autoload": {
-    "classmap": [
-      "jsnao.php"
-    ]
+    "psr-4": {
+      "Jsnao\\": ""
+    }
   },
   "require-dev": {
     "phpunit/phpunit": "^10"

--- a/jsnao.php
+++ b/jsnao.php
@@ -1,111 +1,111 @@
-<?
-/*
- * 取材自網友 http://bbs.phpchina.com/thread-123682-1-1.html 
+<?php
+declare(strict_types=1);
+
+/**
+ * 取材自網友 http://bbs.phpchina.com/thread-123682-1-1.html
  */
-include_once 'jsnao_inputype.php';
+require_once __DIR__ . '/jsnao_inputype.php';
 
 class Jsnao extends ArrayObject
 {
-    protected $version = "1.1.4";
+    protected string $version = '1.1.4';
 
     /**
      * 獲取 ArrayObject 因子
-     * @param mix $mix  可輸入的型態或資料格式 string | integer | array | object | json | NULL 
+     * @param mixed $mix  可輸入的型態或資料格式 string | integer | array | object | json | NULL
      */
-    public function __construct($mix = null)
+    public function __construct(mixed $mix = null)
     {
         $array = Jsnao_inputype::filter($mix);
-        foreach ($array as &$value)
-        {
-            is_array($value) && $value = new self($value);
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $value = new self($value);
+            }
         }
         parent::__construct($array);
     }
 
-    public function version ()
+    public function version(): string
     {
         return $this->version;
     }
-    
+
     // 取值
-    public function __get($index)
+    public function __get(string $index): mixed
     {
         return $this->get($index);
     }
 
     // 賦值
-    public function __set($index, $value)
+    public function __set(string $index, mixed $value): void
     {
         $this->put($index, $value);
     }
 
     // 是否存在
-    public function __isset($index)
+    public function __isset(string $index): bool
     {
         return $this->offsetExists($index);
     }
 
     // 刪除
-    public function __unset($index)
+    public function __unset(string $index): void
     {
         $this->offsetUnset($index);
     }
 
     // 轉換為陣列類型
-    public function toArray()
+    public function toArray(): array
     {
         $array = $this->getArrayCopy();
-        foreach ($array as &$value)
-        {
-            ($value instanceof self) && $value = $value->toArray();
+        foreach ($array as &$value) {
+            if ($value instanceof self) {
+                $value = $value->toArray();
+            }
         }
         return $array;
     }
-  
+
     // 輸出成字串
-    public function __toString()
+    public function __toString(): string
     {
         return var_export($this->toArray(), true);
     }
 
     // 輸出到 JavaScript console.log，回傳 $this 可供串接
-    public function log($title = NULL)
+    public function log(?string $title = null): self
     {
-        $string = $this->__toString();
-        if ($title !== NULL)
-        {
-            $this->console_log("'§ -------- {$title} -------- §'", false);
+        if ($title !== null) {
+            $this->consoleLog("'§ -------- {$title} -------- §'", false);
         }
-        $this->console_log($string, true);
-        if ($title !== NULL)
-        {
-            $this->console_log("'                              '", false);
+        $this->consoleLog('', true);
+        if ($title !== null) {
+            $this->consoleLog("'                              '", false);
         }
         return $this;
     }
 
-    private function console_log($string, $isencode = false)
+    private function consoleLog(string $string, bool $encode = false): void
     {
-        if ($isencode == true)
-        {
-            $string = json_encode($this->toArray());
+        if ($encode) {
+            $string = json_encode($this->toArray(), JSON_THROW_ON_ERROR);
         }
         echo "<script>console.log({$string})</script>";
     }
-    
+
     // 根據索引賦值
-    public function put($index, $value)
+    public function put(mixed $index, mixed $value): void
     {
-        is_array($value) && $value = new self($value);
-        return $this->offsetSet($index, $value);
+        if (is_array($value)) {
+            $value = new self($value);
+        }
+        $this->offsetSet($index, $value);
     }
-    
+
     // 根據索引取值
-    public function get($index)
+    public function get(mixed $index): mixed
     {
         return $this->offsetGet($index);
     }
 }
 
-
-?>

--- a/jsnao_inputype.php
+++ b/jsnao_inputype.php
@@ -1,55 +1,65 @@
-<?
+<?php
+declare(strict_types=1);
+
 /**
  * 輸入的格式過濾，最後都會回傳陣列
  */
 class Jsnao_inputype
 {
     //唯一對外的呼叫方法。依照輸入的型態對應適合的方法
-    static public function filter($mix)
+    public static function filter(mixed $mix): array
     {
-        $method = "is_" . gettype($mix);
+        $method = 'is_' . gettype($mix);
 
-        if (self::is_method($method))
-        {
+        if (self::is_method($method)) {
             return self::$method($mix);
         }
         return self::is_string($mix);
     }
 
     //是否存在這個方法？
-    static private function is_method($method)
+    private static function is_method(string $method): bool
     {
-        $cname = __CLASS__;
-        return method_exists(new $cname, $method);
+        return method_exists(__CLASS__, $method);
     }
-    static private function is_boolean($mix)
+
+    private static function is_boolean($mix): array
     {
-        return array();
+        return [];
     }
-    static private function is_string($mix)
+
+    private static function is_string(string $mix): array
     {
         $decode = json_decode($mix, true);
-        if (gettype($decode) == "array") return $decode;
+        if (is_array($decode)) {
+            return $decode;
+        }
         return self::wrap_element($mix);
     }
-    static private function is_array($mix)
+
+    private static function is_array(array $mix): array
     {
-        return $array = $mix;
+        return $mix;
     }
-    static private function is_object($mix)
+
+    private static function is_object(object $mix): array
     {
-        return json_decode(json_encode($mix), true);
+        return json_decode(json_encode($mix, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
     }
-    static private function is_NULL($mix)
+
+    private static function is_NULL($mix): array
     {
-        return array();
+        return [];
     }
-    static private function wrap_element($mix)
+
+    private static function wrap_element(mixed $mix): array
     {
-        return array('data' => $mix);
+        return ['data' => $mix];
     }
-    static public function __callStatic($name, $arguments)
+
+    public static function __callStatic(string $name, array $arguments): array
     {
-        return self::wrap_element($arguments[0]);
+        return self::wrap_element($arguments[0] ?? null);
     }
 }
+

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Jsnao Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# install PHP and Composer if not present
+if ! command -v php >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y php-cli php-mbstring php-xml composer
+fi
+
+composer install
+vendor/bin/phpunit --configuration phpunit.xml.dist

--- a/tests/JsnaoTest.php
+++ b/tests/JsnaoTest.php
@@ -3,8 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
-
-require_once __DIR__ . '/../jsnao.php';
+use Jsnao\Jsnao;
 
 class JsnaoTest extends TestCase
 {
@@ -94,5 +93,27 @@ class JsnaoTest extends TestCase
             '002' => ['name' => 'banana'],
         ];
         $this->assertSame($expected, $cart->toArray());
+    }
+
+    public function testStringInput(): void
+    {
+        $str = 'Hello World';
+        $obj = new Jsnao($str);
+        $this->assertSame(['data' => 'Hello World'], $obj->toArray());
+    }
+
+    public function testObjectInput(): void
+    {
+        $o = new \stdClass();
+        $o->foo = 'bar';
+        $obj = new Jsnao($o);
+        $this->assertSame('bar', $obj->foo);
+    }
+
+    public function testJsonInput(): void
+    {
+        $json = '{"foo":"bar"}';
+        $obj = new Jsnao($json);
+        $this->assertSame('bar', $obj->foo);
     }
 }

--- a/tests/JsnaoTest.php
+++ b/tests/JsnaoTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../jsnao.php';
+
+class JsnaoTest extends TestCase
+{
+    public function testSimpleUsage(): void
+    {
+        $cart = [
+            'A001' => ['name' => 'apple'],
+            1000   => ['name' => 'water'],
+        ];
+        $cart = new Jsnao($cart);
+
+        // Get
+        $this->assertSame('apple', $cart->A001->name);
+        $this->assertSame('water', $cart->get(1000)->name);
+
+        // Set
+        $cart->A002 = ['name' => 'banana'];
+        $cart->A002 = [];
+        $cart->A002->name = 'banana';
+        $cart->put(2000, ['name' => 'lemon']);
+
+        // Modify
+        $cart->A001->name = 'cherry';
+
+        // Delete
+        $cart->A003 = ['name' => 'bag'];
+        unset($cart->A003);
+
+        $expected = [
+            'A001' => ['name' => 'cherry'],
+            1000   => ['name' => 'water'],
+            'A002' => ['name' => 'banana'],
+            2000   => ['name' => 'lemon'],
+        ];
+        $this->assertSame($expected, $cart->toArray());
+    }
+
+    public function testArrayAccess(): void
+    {
+        $cart = [
+            '001' => ['name' => 'apple'],
+        ];
+        $cart = new Jsnao($cart);
+
+        // Get
+        $this->assertSame('apple', $cart['001']['name']);
+
+        // Set
+        $cart['002']['name'] = 'banana';
+
+        // Modify
+        $cart['001']['name'] = 'cherry';
+
+        // Delete
+        $cart['003']['name'] = 'bag';
+        unset($cart['003']);
+
+        $expected = [
+            '001' => ['name' => 'cherry'],
+            '002' => ['name' => 'banana'],
+        ];
+        $this->assertSame($expected, $cart->toArray());
+    }
+
+    public function testArrayObjectMethods(): void
+    {
+        $cart = [
+            '001' => ['name' => 'apple'],
+        ];
+        $cart = new Jsnao($cart);
+
+        // Get
+        $this->assertSame('apple', $cart->offsetGet('001')->name);
+
+        // Set
+        $cart->offsetSet('002', ['name' => 'banana']);
+
+        // Modify
+        $cart->offsetGet('001')->offsetSet('name', 'cherry');
+
+        // Delete
+        $cart->offsetSet('003', ['name' => 'bag']);
+        $cart->offsetUnset('003');
+
+        $expected = [
+            '001' => ['name' => 'cherry'],
+            '002' => ['name' => 'banana'],
+        ];
+        $this->assertSame($expected, $cart->toArray());
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit tests based on demo scripts
- require phpunit for development
- provide phpunit.xml for running the test suite

## Testing
- `php -l jsnao.php` *(fails: command not found)*
- `vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f98a3f0888320ac68dd3211d98bcc